### PR TITLE
Allow user ID to be longer than 32 characters

### DIFF
--- a/chainpad-netflux.js
+++ b/chainpad-netflux.js
@@ -145,7 +145,7 @@ var factory = function (Netflux, Nacl, NaclUtil) {
 
         var onJoining = function(peer) {
             if (config.onJoin)  { config.onJoin(peer); }
-            if(peer.length !== 32) { return; }
+            if(peer.length < 32) { return; }
             var list = userList.users;
             var index = list.indexOf(peer);
             if(index === -1) {


### PR DESCRIPTION
It can't be less because we need to distinguish the history keeper, which currently has an ID of length 16.

Note that we need this because we're refactoring our Netflux back-end to support clustering, and it would be very convenient for us to set the user ID like this:

    userId: <clusterNodeId>-<webSocketSessionId>

Unfortunately this leads to user IDs longer than 32 characters, which are currently forbidden by the ``chainpad-netflux`` module.